### PR TITLE
Expose formatted agent output and propagate test mode

### DIFF
--- a/cli/subcommands/agent.py
+++ b/cli/subcommands/agent.py
@@ -1,3 +1,18 @@
+import typer
+from pathlib import Path
+
+from rag.md_loader import load_markdown_chunks
+
+try:
+    from agents.base_flow import run_agent_flow
+except Exception:  # pragma: no cover - fallback for missing optional deps
+    run_agent_flow = None  # type: ignore
+
+
+app = typer.Typer(help="Agent-related commands")
+agent_app = app
+
+
 @app.command("question")
 def ask_question(
     query: str = typer.Argument(..., help="Your query or question"),
@@ -17,10 +32,17 @@ def ask_question(
         }
 
         result = run_agent_flow(input_data)
+
         if isinstance(result, dict) and "formatted_output" in result:
-            typer.secho(result["formatted_output"], fg=typer.colors.GREEN)
+            output = result["formatted_output"]
+            typer.secho(output, fg=typer.colors.GREEN)
         else:
-            typer.secho("[No formatted output]", fg=typer.colors.YELLOW)
+            output = "[No formatted output]"
+            typer.secho(output, fg=typer.colors.YELLOW)
+
+        return output
 
     except Exception as e:
-        typer.secho(f"[ERROR] {e}", fg=typer.colors.RED)
+        error_msg = f"[ERROR] {e}"
+        typer.secho(error_msg, fg=typer.colors.RED)
+        return error_msg

--- a/tests/test_ask_question.py
+++ b/tests/test_ask_question.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+import cli.subcommands.agent as agent_module
+
+
+def test_ask_question_returns_output_and_passes_test_mode(monkeypatch):
+    captured = {}
+
+    def fake_run_agent_flow(data):
+        captured["data"] = data
+        return {"formatted_output": "### answer\n[TEST MODE] example"}
+
+    monkeypatch.setattr(agent_module, "run_agent_flow", fake_run_agent_flow)
+
+    result = agent_module.ask_question("What?", Path("docs/sample.md"), test_mode=True)
+
+    assert "[TEST MODE]" in result
+    assert captured["data"]["test_mode"] is True
+
+
+def test_ask_question_handles_missing_output(monkeypatch):
+    def fake_run_agent_flow(data):
+        return {}
+
+    monkeypatch.setattr(agent_module, "run_agent_flow", fake_run_agent_flow)
+
+    result = agent_module.ask_question("What?", Path("docs/sample.md"), test_mode=True)
+
+    assert result == "[No formatted output]"


### PR DESCRIPTION
## Summary
- ensure `ask_question` CLI subcommand prints and returns the formatted agent response
- forward `test_mode` flag through the CLI so flow's thinker emits `[TEST MODE]` content
- add unit tests covering normal and fallback cases

## Testing
- `pytest tests/test_ask_question.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_community'; ModuleNotFoundError: No module named 'langgraph'; requests.exceptions.ProxyError when fetching HuggingFace models, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6890d512ca308322a5c6bc5794795ca9