### PR TITLE
refactor: expose agent app module

### DIFF
--- a/cli/agent.py
+++ b/cli/agent.py
@@ -1,33 +1,13 @@
-import typer
-from pathlib import Path
-from agents.base_flow import run_agent_flow
-from rag.md_loader import load_markdown_chunks
+"""Command-line wrapper for the Soothsayer agent CLI.
 
-cli_app = typer.Typer(help="Soothsayer Agent Commands")  # 👈 required by main.py
+This module simply exposes the agent's Typer application from
+``cli.subcommands.agent`` so that it can be invoked as a module via
+``python -m cli.agent``.
+"""
 
-@cli_app.command("ask")
-def ask_command(
-    query: str = typer.Option(..., help="Your query or question"),
-    file: Path = typer.Option(..., exists=True, help="Path to markdown file"),
-    test_mode: bool = typer.Option(True, help="Run in test mode (no LLM call)")
-):
-    """Ask a question using Soothsayer Agent."""
-    try:
-        chunks = load_markdown_chunks(file_path=str(file))  # ✅ Explicit keyword
+from cli.subcommands.agent import agent_app as app
 
-        input_data = {
-            "query": query,
-            "chunks": chunks,
-            "test_mode": test_mode
-        }
 
-        result = run_agent_flow(input_data)
+if __name__ == "__main__":
+    app()
 
-        # ✅ FIX: This block must be indented under `try`
-        if isinstance(result, dict) and "formatted_output" in result:
-            typer.secho(result["formatted_output"], fg=typer.colors.GREEN)
-        else:
-            typer.secho("[No formatted output]", fg=typer.colors.YELLOW)
-
-    except Exception as e:
-        typer.secho(f"[ERROR] {str(e)}", fg=typer.colors.RED)

--- a/cli/subcommands/agent.py
+++ b/cli/subcommands/agent.py
@@ -1,11 +1,36 @@
-@app.command("question")
+"""Typer application for the Soothsayer agent subcommands."""
+
+from pathlib import Path
+
+import typer
+
+
+agent_app = typer.Typer(help="Soothsayer Agent Commands")
+
+
+@agent_app.callback()
+def agent_cli() -> None:
+    """Entry point for agent-related commands."""
+    # This function ensures the ``question`` command is exposed as a subcommand
+    # so that the CLI is invoked as ``python -m cli.agent question ...``.
+    pass
+
+
+@agent_app.command("question")
 def ask_question(
     query: str = typer.Argument(..., help="Your query or question"),
-    file: Path = typer.Option(..., exists=True, file_okay=True, readable=True, help="Path to markdown file"),
-    test_mode: bool = typer.Option(True, help="Run in test mode (no LLM call)")
+    file: Path = typer.Option(
+        ..., exists=True, file_okay=True, readable=True, help="Path to markdown file"
+    ),
+    test_mode: bool = typer.Option(True, help="Run in test mode (no LLM call)"),
 ):
-    """Ask a question using Soothsayer Agent."""
+    """Ask a question using the Soothsayer Agent."""
     try:
+        # Import heavy dependencies lazily so that ``--help`` works even when
+        # optional packages are missing.
+        from agents.base_flow import run_agent_flow
+        from rag.md_loader import load_markdown_chunks
+
         file_path = str(file.resolve())
         chunks = load_markdown_chunks(file_path=file_path)
 
@@ -13,7 +38,7 @@ def ask_question(
             "query": query,
             "chunks": chunks,
             "test_mode": test_mode,
-            "file_path": file_path
+            "file_path": file_path,
         }
 
         result = run_agent_flow(input_data)
@@ -21,6 +46,9 @@ def ask_question(
             typer.secho(result["formatted_output"], fg=typer.colors.GREEN)
         else:
             typer.secho("[No formatted output]", fg=typer.colors.YELLOW)
-
     except Exception as e:
         typer.secho(f"[ERROR] {e}", fg=typer.colors.RED)
+
+
+__all__ = ["agent_app"]
+


### PR DESCRIPTION
## Summary
- thin wrapper module `cli/agent.py` to expose `agent_app`
- new `agent_app` Typer CLI in `cli/subcommands/agent.py` with lazily-imported dependencies and `question` command

## Testing
- `python -m cli.agent --help`
- `python -m cli.agent question --help`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_community', ModuleNotFoundError: No module named 'langgraph', requests.exceptions.ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_6890d50f35f883228e6ca08c6c738f06